### PR TITLE
Add fieldsets to dialogs

### DIFF
--- a/templates/card/dialog-draw.hbs
+++ b/templates/card/dialog-draw.hbs
@@ -1,6 +1,8 @@
-<p class="hint">{{localize "CARDS.DrawHint"}}</p>
+<fieldset>
+  <p class="hint">{{localize "CARDS.DrawHint"}}</p>
 
-{{formGroup from localize=true sort=true name="from"}}
-{{formGroup number localize=true name="number"}}
-{{formGroup how localize=true name="how"}}
-{{formGroup down localize=true name="down"}}
+  {{formGroup from localize=true sort=true name="from"}}
+  {{formGroup number localize=true name="number"}}
+  {{formGroup how localize=true name="how"}}
+  {{formGroup down localize=true name="down"}}
+</fieldset>

--- a/templates/card/dialog-pass.hbs
+++ b/templates/card/dialog-pass.hbs
@@ -1,6 +1,8 @@
-<p>{{localize "CARDS.PassHint"}}</p>
+<fieldset>
+  <p class="hint">{{localize "CARDS.PassHint"}}</p>
 
-{{formGroup to localize=true sort=true name="to" blank=false}}
-{{formGroup number localize=true name="number" value=1}}
-{{formGroup how localize=true name="how"}}
-{{formGroup down localize=true name="down"}}
+  {{formGroup to localize=true sort=true name="to" blank=false}}
+  {{formGroup number localize=true name="number" value=1}}
+  {{formGroup how localize=true name="how"}}
+  {{formGroup down localize=true name="down"}}
+</fieldset>

--- a/templates/card/dialog-play.hbs
+++ b/templates/card/dialog-play.hbs
@@ -1,8 +1,11 @@
 <figure>
-  <img class="thumbnail" src="{{card.img}}" height="480">
+  <img class="thumbnail" src="{{card.img}}" height="320">
   <figcaption>{{card.name}}</figcaption>
 </figure>
-<p class="hint">{{localize "CARD.PlayHint"}}</p>
 
-{{formGroup to localize=true name="to"}}
-{{formGroup down localize=true name="down"}}
+<fieldset>
+  <p class="hint">{{localize "CARD.PlayHint"}}</p>
+
+  {{formGroup to localize=true name="to"}}
+  {{formGroup down localize=true name="down"}}
+</fieldset>


### PR DESCRIPTION
Add `<fieldset>` to remaining custom dialogs. Looks nicer.

Lowered the size of the card image in `playDialog` (it was way too big).