### PR TITLE
Remove value on card's "Rotation" field if falsy.

### DIFF
--- a/src/module/apps/CardSheet.mjs
+++ b/src/module/apps/CardSheet.mjs
@@ -105,7 +105,10 @@ export default class CardSheet extends HandlebarsApplicationMixin(DocumentSheetV
     context.value = makeField("value");
     context.width = makeField("width", {placeholder: game.i18n.localize("Width")});
     context.height = makeField("height", {placeholder: game.i18n.localize("Height")});
-    context.rotation = makeField("rotation", {value: this.document.rotation || null, placeholder: game.i18n.localize("Rotation")});
+    context.rotation = makeField("rotation", {
+      value: this.document.rotation || "",
+      placeholder: game.i18n.localize("Rotation")
+    });
     context.description = makeField("description", {
       enriched: await TextEditor.enrichHTML(this.document.description, {relativeTo: this.document})
     });


### PR DESCRIPTION
Small visual change to display nothing but the placeholder in the 'Rotation' field if the card's rotation is `null` or `0`.

This works around a core issue (already reported) where `null` can never be displayed when using `{{formGroup}}` with a number field.