### PR TITLE
[#65] Add scrying application

### DIFF
--- a/ccm.css
+++ b/ccm.css
@@ -142,3 +142,12 @@
     }
   }
 }
+.ccm.scry {
+  max-height: 90%;
+
+  [data-application-part=cards] {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    margin-right: 0.5rem;
+  }
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -66,6 +66,11 @@
       "NextFace": "Next Face",
       "PreviousFace": "Previous Face"
     },
+    "Dialogs": {
+      "Scry": {
+        "Title": "Scrying on: {name}"
+      }
+    },
     "Warning": {
       "NoCardsAvailable": "This {type} has no cards available.",
       "CardDrawn": "This card cannot be added to the canvas as it has already been drawn and added to a pile or hand.",

--- a/src/module/api/_module.mjs
+++ b/src/module/api/_module.mjs
@@ -1,2 +1,3 @@
 export * from "./singles.mjs";
 export * from "./layout.mjs";
+export * from "./scry.mjs";

--- a/src/module/api/scry.mjs
+++ b/src/module/api/scry.mjs
@@ -1,0 +1,100 @@
+const {HandlebarsApplicationMixin, ApplicationV2} = foundry.applications.api;
+
+/**
+ * Scry on a number of cards in a deck, hand, or pile.
+ * @param {Cards} deck                                            The deck, hand, or pile on which to spy.
+ * @param {object} [options={}]                                   Options that modify the scrying.
+ * @param {number} [options.amount=1]                             The number of cards to reveal.
+ * @param {number} [options.how=CONST.CARD_DRAW_MODES.FIRST]      From where in the deck to draw the cards to scry on.
+ */
+export async function scry(deck, {amount = 1, how = CONST.CARD_DRAW_MODES.FIRST} = {}) {
+  const cards = deck._drawCards(amount, how);
+  ScryDialog.create(cards);
+  // TODO: replace cards with specific method or in specific order.
+}
+
+/**
+ * Utility class for scrying.
+ */
+class ScryDialog extends HandlebarsApplicationMixin(ApplicationV2) {
+  /**
+   * @class
+   * @param {object} [options]            Application rendering options.
+   * @param {Card[]} [options.cards]      The revealed cards.
+   */
+  constructor({cards, ...options} = {}) {
+    super(options);
+    this.#cards = cards ?? [];
+    this.#deck = cards[0]?.parent ?? null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Factory method to create an instance of this application.
+   * @param {Card[]} cards          The revealed cards.
+   * @param {object} [options]      Application rendering options.
+   */
+  static create(cards, options = {}) {
+    options.cards = cards;
+    new this(options).render({force: true});
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ["ccm", "scry"],
+    modal: true,
+    rejectClose: false,
+    position: {
+      width: 600,
+      height: "auto"
+    },
+    window: {
+      icon: "fa-solid fa-eye",
+      contentClasses: ["standard-form", "scrollable"]
+    }
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    cards: {template: "modules/complete-card-management/templates/card/scrying.hbs"}
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  async _prepareContext(options) {
+    const context = {};
+    context.cards = this.#cards;
+    return context;
+  }
+
+  /* -------------------------------------------------- */
+  /*   Properties                                       */
+  /* -------------------------------------------------- */
+
+  /**
+   * The cards being revealed.
+   * @type {Card[]}
+   */
+  #cards = null;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The deck from which cards are being revealed.
+   * @type {Cards}
+   */
+  #deck = null;
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  get title() {
+    return game.i18n.format("CCM.Dialogs.Scry.Title", {name: this.#deck.name});
+  }
+}

--- a/templates/card/scrying.hbs
+++ b/templates/card/scrying.hbs
@@ -1,0 +1,8 @@
+<fieldset>
+  {{#each cards}}
+  <figure>
+    <img class="thumbnail" src="{{img}}">
+    <figcaption>{{name}}</figcaption>
+  </figure>
+  {{/each}}
+</fieldset>


### PR DESCRIPTION
Adds a simple scrying application accessed via api.

Optionally changing the order of the cards is follow-up work.

![image](https://github.com/user-attachments/assets/50ce06f6-c852-4de6-95f7-4c62bf1f8fa5)

Closes #65.