### PR TITLE
[#91] Persist shuffle

### DIFF
--- a/src/module/apps/CardsSheet.mjs
+++ b/src/module/apps/CardsSheet.mjs
@@ -176,7 +176,7 @@ class CardsSheet extends HandlebarsApplicationMixin(DocumentSheetV2) {
    * The current sorting method of this deck.
    * @type {string}
    */
-  #sort = "standard";
+  #sort = "shuffled";
   get sort() {
     return this.#sort;
   }


### PR DESCRIPTION
Closes #91.

Seems like the only actual difference between the regular and custom Cards sheets was that the default had 'shuffled' as the default (set in `defaultOptions`) and we had 'standard'.