### PR TITLE
Updated Readme, Module.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.1
+
+- Removed `compatibility.systems` field from the module.json, allowing this module to be used with any system, not just SWADE and UTS.
+
+## 1.0.0 Official Release
+
+- Improved title on Card Sheet
+- Added option to the allocate card region behavior to delete canvas cards dropped there (default: true)
+
 ## 0.9.1 Beta Release 2
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.1
 
-- Removed `compatibility.systems` field from the module.json, allowing this module to be used with any system, not just SWADE and UTS.
+- Removed `compatibility.systems` field from the module.json, allowing this module to be used with any system, not just SWADE and UTS. [#146]
 
 ## 1.0.0 Official Release
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Complete Card Management
 
 A FVTT module that allows users to manipulate cards as part of the canvas.
+
+## Installation
+
+You can install the module by pasting the following URL into the **Install Module** dialog on the Setup menu of your Foundry application.
+
+https://github.com/MetaMorphic-Digital/complete-card-management/releases/latest/download/module.json
+
+You can also download specific versions by visiting the [Releases](https://github.com/MetaMorphic-Digital/complete-card-management/releases) page for the repository and copying the appropriate `module.json` URL and pasting it into the install module dialog.

--- a/module.json
+++ b/module.json
@@ -29,27 +29,6 @@
     "minimum": "12.328",
     "verified": "12.331"
   },
-  "relationships": {
-    "systems": [
-      {
-        "id": "universal-tabletop-system",
-        "type": "system",
-        "manifest": "https://github.com/MetaMorphic-Digital/universal-tabletop-system/releases/latest/download/system.json",
-        "compatibility": {
-          "verified": "0.8"
-        }
-      },
-      {
-        "id": "swade",
-        "type": "system",
-        "manifest": "https://gitlab.com/api/v4/projects/16269883/packages/generic/swade/latest/system.json",
-        "compatibility": {
-          "minimum": "4.0.0",
-          "verified": "4"
-        }
-      }
-    ]
-  },
   "esmodules": ["./ccm.mjs"],
   "styles": ["./ccm.css"],
   "languages": [


### PR DESCRIPTION
- Updated README with install instructions
- Removed `compatibility.systems` field from the module.json, allowing this module to be used with any system, not just SWADE and UTS.
