### PR TITLE
Type import improvements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
+  "ignorePatterns": ["foundry/**/*.mjs"],
   "rules": {
     "indent": ["error", 2, {"SwitchCase": 1}],
     "linebreak-style": [

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "module": "ES6",
-    "target": "ES6"
+    "target": "ES6",
+    "paths": {
+      "@client/*": ["./foundry/client/*"],
+      "@common/*": ["./foundry/common/*"]
+    },
   },
   "exclude": ["node_modules", "**/node_modules/*"],
   "include": ["ccm.mjs", "foundry/client/client.mjs"],

--- a/src/module/canvas/CanvasCard.mjs
+++ b/src/module/canvas/CanvasCard.mjs
@@ -215,7 +215,7 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     return CONFIG.defaultFontFamily || "Signika";
   }
 
-  /** @import Color from "../../../foundry/common/utils/color.mjs" */
+  /** @import Color from "@common/utils/color.mjs" */
 
   /**
    * The color of the text displayed within this card

--- a/src/module/hooks.mjs
+++ b/src/module/hooks.mjs
@@ -5,8 +5,6 @@ import CCM_CONFIG from "./config.mjs";
 import {checkHandDisplayUpdate, MODULE_ID, MoveCardType} from "./helpers.mjs";
 import {addCard, removeCard} from "./patches.mjs";
 
-/** @import SceneConfig from "../../foundry/client/applications/sheets/scene-config.mjs"; */
-
 /**
  * Run on Foundry init
  */
@@ -32,19 +30,21 @@ export function init() {
 
   ccm_canvas.CanvasCard.registerSettings();
 
-  foundry.applications.apps.DocumentSheetConfig.registerSheet(Cards, MODULE_ID, apps.CardsSheets.DeckSheet, {
+  const {DocumentSheetConfig} = foundry.applications.apps;
+
+  DocumentSheetConfig.registerSheet(Cards, MODULE_ID, apps.CardsSheets.DeckSheet, {
     label: "CCM.Sheets.Deck", types: ["deck"]
   });
-  foundry.applications.apps.DocumentSheetConfig.registerSheet(Cards, MODULE_ID, apps.CardsSheets.HandSheet, {
+  DocumentSheetConfig.registerSheet(Cards, MODULE_ID, apps.CardsSheets.HandSheet, {
     label: "CCM.Sheets.Hand", types: ["hand"]
   });
-  foundry.applications.apps.DocumentSheetConfig.registerSheet(Cards, MODULE_ID, apps.CardsSheets.DockedHandSheet, {
+  DocumentSheetConfig.registerSheet(Cards, MODULE_ID, apps.CardsSheets.DockedHandSheet, {
     label: "CCM.Sheets.DockedHand", types: ["hand"]
   });
-  foundry.applications.apps.DocumentSheetConfig.registerSheet(Cards, MODULE_ID, apps.CardsSheets.PileSheet, {
+  DocumentSheetConfig.registerSheet(Cards, MODULE_ID, apps.CardsSheets.PileSheet, {
     label: "CCM.Sheets.Pile", types: ["pile"]
   });
-  foundry.applications.apps.DocumentSheetConfig.registerSheet(Card, MODULE_ID, apps.CardSheet, {
+  DocumentSheetConfig.registerSheet(Card, MODULE_ID, apps.CardSheet, {
     label: "CCM.Sheets.Card"
   });
 
@@ -291,7 +291,7 @@ export function renderHeadsUpDisplayContainer(app, html, context, options) {
   html.appendChild(cardHudTemplate);
 }
 
-/** @import UserConfig from "../../foundry/client/applications/sheets/user-config.mjs" */
+/** @import UserConfig from "@client/applications/sheets/user-config.mjs" */
 
 /**
  * A hook called when the UserConfig application opens
@@ -391,6 +391,8 @@ export function getUserContextOptions(html, contextOptions) {
   });
 }
 
+/** @typedef {import("@client/applications/sheets/scene-config.mjs").default} SceneConfig */
+
 /**
  * Add Scene pile selection
  * @param {SceneConfig} app
@@ -477,7 +479,7 @@ export async function createScene(scene, options, userId) {
 
 /* -------------------------------------------------- */
 
-/** @typedef {import("../../foundry/client/applications/sidebar/tabs/cards-directory.mjs").default} CardsDirectory */
+/** @typedef {import("@client/applications/sidebar/tabs/cards-directory.mjs").default} CardsDirectory */
 
 /**
  * Add additional context options to cards in cards directory.

--- a/tools/create-symlinks.mjs
+++ b/tools/create-symlinks.mjs
@@ -11,7 +11,10 @@ if (fs.existsSync("foundry-config.yaml")) {
 
     const foundryConfig = yaml.load(fc);
 
-    fileRoot = path.join(foundryConfig.installPath, "resources", "app");
+    // As of 13.338, the Node install is *not* nested but electron installs *are*
+    const nested = fs.existsSync(path.join(foundryConfig.installPath, "resources", "app"));
+
+    if (nested) fileRoot = path.join(foundryConfig.installPath, "resources", "app");
   } catch (err) {
     console.error(`Error reading foundry-config.yaml: ${err}`);
   }

--- a/tools/create-symlinks.mjs
+++ b/tools/create-symlinks.mjs
@@ -15,6 +15,7 @@ if (fs.existsSync("foundry-config.yaml")) {
     const nested = fs.existsSync(path.join(foundryConfig.installPath, "resources", "app"));
 
     if (nested) fileRoot = path.join(foundryConfig.installPath, "resources", "app");
+    else fileRoot = foundryConfig.installPath;
   } catch (err) {
     console.error(`Error reading foundry-config.yaml: ${err}`);
   }


### PR DESCRIPTION
- Applied node flattening patch to createSymlinks script
- Added `@` paths for both improving types produced by foundry as well as simplifying our own type imports.
- Destructured the DocumentSheetConfig reference