### PR TITLE
[#201] Adjusted CardLayer zIndex to be -100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.1.2
 - Fixed an issue where a canvas card could end up with a height and width of zero. The new minimums are CONST.GRID_SIZE, which is currently 20px.
+- Adjusted the z index of the Cards layer so it is below the layer created by the Sequencer module.
+- Fixed an issue with dragging and dropping to and from the Docked sheet.
 
 ## 2.1.1
 - Added "Draw" button to the docked hand sheet header controls

--- a/module.json
+++ b/module.json
@@ -26,7 +26,7 @@
   ],
   "version": "AUTOMATIC",
   "compatibility": {
-    "minimum": "13.347",
+    "minimum": "13.351",
     "verified": "13"
   },
   "esmodules": ["./ccm.mjs"],

--- a/src/module/canvas/CardLayer.mjs
+++ b/src/module/canvas/CardLayer.mjs
@@ -21,7 +21,7 @@ export default class CardLayer extends foundry.canvas.layers.PlaceablesLayer {
       name: "cards",
       controllableObjects: true,
       rotatableObjects: true,
-      zIndex: 100
+      zIndex: -100
     });
   }
 

--- a/src/module/canvas/CardLayer.mjs
+++ b/src/module/canvas/CardLayer.mjs
@@ -118,7 +118,7 @@ export default class CardLayer extends foundry.canvas.layers.PlaceablesLayer {
     itf.cardMeshes.sortableChildren = true;
     itf.cardMeshes.eventMode = "none";
     itf.cardMeshes.interactiveChildren = false;
-    itf.cardMeshes.zIndex = 100;
+    itf.cardMeshes.zIndex = this.getZIndex();
 
     // Layer functionality
     // Inherited from InteractionLayer


### PR DESCRIPTION
There appears to be no adverse effects to going into the negatives. The problem is caused by sequencer opting to have a zIndex of 0 for all of its layers.