### PR TITLE
[#197] Pings

### DIFF
--- a/src/module/canvas/CanvasCard.mjs
+++ b/src/module/canvas/CanvasCard.mjs
@@ -1,9 +1,13 @@
 
 import {MODULE_ID} from "../helpers.mjs";
 
-/** @import CardLayer from "./CardLayer.mjs"; */
-/** @import DocumentSheetV2 from "@client/applications/api/document-sheet.mjs"; */
-/** @import {Card, Cards} from "@client/documents/_module.mjs" */
+/**
+ * @import Color from "@common/utils/color.mjs"
+ * @import DocumentSheetV2 from "@client/applications/api/document-sheet.mjs";
+ * @import {Card, Cards} from "@client/documents/_module.mjs"
+ * @import CardLayer from "./CardLayer.mjs";
+ * @import CardObject from "./CardObject.mjs";
+ */
 
 /**
  * A data model that captures the necessary characteristics for a CardObject on the canvas
@@ -53,6 +57,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     this.card = card;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Synthetic parent
    * @type {Scene}
@@ -60,7 +66,7 @@ export default class CanvasCard extends foundry.abstract.DataModel {
   // Using this.parent so that way it sticks after constructor.
   parent = this.parent ?? null;
 
-  /** @import CardObject from "./CardObject.mjs" */
+  /* -------------------------------------------------- */
 
   /**
    * A lazily constructed PlaceableObject instance which can represent this Document on the game canvas.
@@ -79,7 +85,11 @@ export default class CanvasCard extends foundry.abstract.DataModel {
   // Using this._object so that way it sticks after constructor.
   _object = this._object ?? null;
 
+  /* -------------------------------------------------- */
+
   static LOCALIZATION_PREFIXES = ["CCM", "CardObjectModel"];
+
+  /* -------------------------------------------------- */
 
   static defineSchema() {
     const {NumberField, AngleField, IntegerSortField, BooleanField} = foundry.data.fields;
@@ -132,11 +142,15 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     };
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Properties fetched from the appropriate flag
    * @type {string[]}
    */
   static flagProps = ["x", "y", "elevation", "sort", "rotation", "hidden", "locked", "flipped"];
+
+  /* -------------------------------------------------- */
 
   static registerSettings() {
     game.settings.register(MODULE_ID, "showOwner", {
@@ -184,6 +198,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     });
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * The linked card's ID
    * @type {string}
@@ -191,6 +207,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
   get id() {
     return this.card.id;
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * The linked card's UUID
@@ -200,6 +218,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     return this.card.uuid;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * The linked card's document name
    * @type {"Card" | "Cards"}
@@ -208,6 +228,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     return this.card.documentName;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * The canvas card layer
    * @type {CardLayer}
@@ -215,6 +237,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
   get layer() {
     return canvas.cards;
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * The linked document sheet for the Card
@@ -225,12 +249,16 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     return this.card.sheet;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * The font size used to display text within this card
    */
   get fontSize() {
     return game.settings.get(MODULE_ID, "ownerFontSize");
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * The font family used to display text within this card
@@ -240,7 +268,7 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     return CONFIG.defaultFontFamily || "Signika";
   }
 
-  /** @import Color from "@common/utils/color.mjs" */
+  /* -------------------------------------------------- */
 
   /**
    * The color of the text displayed within this card
@@ -249,6 +277,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
   get textColor() {
     return game.settings.get(MODULE_ID, "ownerTextColor");
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * The name of the user who owns this card
@@ -265,6 +295,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     return owner?.name ?? "";
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * The opacity of text displayed on this card
    * @returns {number}
@@ -273,11 +305,15 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     return 1;
   }
 
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   clone(data = {}, context = {}) {
     // TODO: Possible refactor actually using the data and context object?
     return new this.constructor(this.card);
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Translate update operations on the original card to this synthetic document
@@ -338,6 +374,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     this.object?._onUpdate(updates, options, userId);
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Refreshes the canvas card's face
    */
@@ -359,6 +397,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     this.updateSource(updates);
     this.object?._onUpdate(updates, {}, "");
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Trigger leave and enter region behaviors for the custom region type & event triggers
@@ -428,6 +468,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     return this.card.pass(canvasPile);
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Handles the deletion process for this synthetic document
    * @param {*} options
@@ -439,6 +481,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     this.card.canvasCard = undefined;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Synthetic passthrough
    * @returns {boolean}
@@ -446,6 +490,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
   get isOwner() {
     return this.card.isOwner;
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Synthetic pass through
@@ -455,6 +501,8 @@ export default class CanvasCard extends foundry.abstract.DataModel {
   canUserModify(...args) {
     return this.card.canUserModify(...args);
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Synthetic pass through

--- a/src/module/canvas/CardLayer.mjs
+++ b/src/module/canvas/CardLayer.mjs
@@ -25,12 +25,16 @@ export default class CardLayer extends foundry.canvas.layers.PlaceablesLayer {
     });
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * The collection of card objects which are rendered in the interface.
    *
    * @type {Map<string, CardObject>}
    */
   graphics = new foundry.utils.Collection();
+
+  /* -------------------------------------------------- */
 
   /**
    * The name used by hooks to construct their hook string.
@@ -41,10 +45,14 @@ export default class CardLayer extends foundry.canvas.layers.PlaceablesLayer {
     return CardLayer.name;
   }
 
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   get hud() {
     return canvas.hud.cards;
   }
+
+  /* -------------------------------------------------- */
 
   // TODO: investigate if there's caching performance improvements
   /** @inheritdoc */
@@ -59,6 +67,8 @@ export default class CardLayer extends foundry.canvas.layers.PlaceablesLayer {
     }, new foundry.utils.Collection());
   }
 
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   getMaxSort() {
     let sort = -Infinity;
@@ -66,6 +76,8 @@ export default class CardLayer extends foundry.canvas.layers.PlaceablesLayer {
     for (const document of collection) sort = Math.max(sort, document.canvasCard.sort);
     return sort;
   }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   async _sendToBackOrBringToFront(front) {
@@ -100,11 +112,15 @@ export default class CardLayer extends foundry.canvas.layers.PlaceablesLayer {
     return true;
   }
 
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   getSnappedPoint(point) {
     if (canvas.forceSnapVertices) return canvas.grid.getSnappedPoint(point, {mode: CONST.GRID_SNAPPING_MODES.VERTEX});
     return super.getSnappedPoint(point);
   }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   async _draw(options) {
@@ -164,6 +180,8 @@ export default class CardLayer extends foundry.canvas.layers.PlaceablesLayer {
     this.objects.visible = true;
   }
 
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   static prepareSceneControls() {
     return {
@@ -222,6 +240,8 @@ export default class CardLayer extends foundry.canvas.layers.PlaceablesLayer {
     };
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * The method to sort the objects elevation and sort before sorting by the z-index.
    * @type {Function}
@@ -237,6 +257,8 @@ export default class CardLayer extends foundry.canvas.layers.PlaceablesLayer {
     );
     this.sortDirty = false;
   };
+
+  /* -------------------------------------------------- */
 
   static #sortMeshesByElevationAndSort = function() {
     for (let i = 0; i < this.children.length; i++) {
@@ -254,6 +276,8 @@ export default class CardLayer extends foundry.canvas.layers.PlaceablesLayer {
     });
     this.sortDirty = false;
   };
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   async rotateMany({angle, delta, snap, ids, includeLocked = false} = {}) {
@@ -284,6 +308,8 @@ export default class CardLayer extends foundry.canvas.layers.PlaceablesLayer {
     await processUpdates(updates);
     return objects;
   }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   async deleteAll() {
@@ -317,11 +343,15 @@ export default class CardLayer extends foundry.canvas.layers.PlaceablesLayer {
     }
   }
 
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   _getCopyableObjects(options) {
     ui.notifications.warn("CCM.Warning.NoCopyCutPaste", {localize: true});
     return [];
   }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   async _onDeleteKey(event) {

--- a/src/module/canvas/CardObject.mjs
+++ b/src/module/canvas/CardObject.mjs
@@ -8,6 +8,9 @@ import CardLayer from "./CardLayer.mjs";
  * CardObjects are drawn inside of the {@link CardLayer} container
  */
 export default class CardObject extends foundry.canvas.placeables.PlaceableObject {
+  /**
+   * @param {CanvasCard} canvasCard
+   */
   constructor(canvasCard) {
     if (!(canvasCard instanceof CanvasCard)) {
       throw new Error("You must provide a CanvasCard to construct a CardObject");
@@ -35,8 +38,7 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
 
   /* -------------------------------------------------- */
 
-  /* -------------------------------------------------- */
-
+  /** @inheritdoc */
   static embeddedName = "Card";
 
   /* -------------------------------------------------- */

--- a/src/module/canvas/CardObject.mjs
+++ b/src/module/canvas/CardObject.mjs
@@ -33,7 +33,13 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     this.document = canvasCard;
   }
 
+  /* -------------------------------------------------- */
+
+  /* -------------------------------------------------- */
+
   static embeddedName = "Card";
+
+  /* -------------------------------------------------- */
 
   /**
    * The texture that is used to fill this Drawing, if any.
@@ -41,11 +47,15 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
    */
   texture;
 
+  /* -------------------------------------------------- */
+
   /**
    * A reference to the SpriteMesh which displays this CardObject in the InterfaceCanvasGroup.
    * @type {SpriteMesh}
    */
   mesh;
+
+  /* -------------------------------------------------- */
 
   /**
    * The border frame for the CardObject.
@@ -53,11 +63,15 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
    */
   frame;
 
+  /* -------------------------------------------------- */
+
   /**
    * A Card background which is displayed if no valid image texture is present
    * @type {PIXI.Graphics}
    */
   bg;
+
+  /* -------------------------------------------------- */
 
   static RENDER_FLAGS = {
     redraw: {propagate: ["refresh"]},
@@ -76,6 +90,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     refreshElevation: {}
   };
 
+  /* -------------------------------------------------- */
+
   /**
    * @inheritdoc
    * @returns {CardLayer}
@@ -83,6 +99,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
   get layer() {
     return canvas["cards"];
   }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   get bounds() {
@@ -107,6 +125,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     return new PIXI.Rectangle(x, y, width, height).normalize();
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Does the CanvasCard have text that is displayed?
    * @type {boolean}
@@ -114,6 +134,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
   get hasText() {
     return !!this.document.text && (this.document.fontSize > 0);
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Is this Card currently visible on the Canvas?
@@ -124,10 +146,14 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     return access || !this.document.hidden || game.user.isGM;
   }
 
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   get id() {
     return this.document.card.uuid;
   }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   get objectId() {
@@ -135,6 +161,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     if (this.isPreview) id += ".preview";
     return id;
   }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   async _draw(options) {
@@ -172,6 +200,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     this.cursor = this.document.isOwner ? "pointer" : null;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Create elements for the Card border and handles
    * @returns {PIXI.Container}
@@ -188,6 +218,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     return frame;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Create a PreciseText element to be displayed as part of this drawing.
    * @returns {PreciseText}
@@ -199,12 +231,16 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     return text;
   }
 
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   _destroy(options) {
     canvas.interface.removeCard(this);
     this.texture?.destroy();
     this.frame?.destroy(); // Unsure if needed? Possibly resolves multi-select frame issue
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Prepare the text style used to instantiate a PIXI.Text or PreciseText instance for this Drawing document.
@@ -227,6 +263,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     });
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Apply render flags before a render occurs.
    * @param {Record<string, boolean>} flags      The render flags which must be applied
@@ -245,7 +283,7 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     if (this.hasActiveHUD) canvas.cards.hud.render();
   }
 
-  /* -------------------------------------------- */
+  /* -------------------------------------------------- */
 
   /**
    * Refresh the displayed state of the CardObject.
@@ -269,6 +307,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     this.mesh.hidden = hidden;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Refresh the rotation.
    * @protected
@@ -279,6 +319,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     this.mesh.angle = rotation;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Refresh the size.
    * @protected
@@ -288,6 +330,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     if (!this.mesh) return this.bg.clear().beginFill(0xFFFFFF, 0.5).drawRect(0, 0, width, height).endFill();
     this._resizeMesh(width, height, {fit, scaleX, scaleY});
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Refresh the position.
@@ -305,6 +349,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     this.mesh.position.set(x + (width / 2), y + (height / 2));
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Refresh the appearance of the CardObject.
    * @protected
@@ -320,6 +366,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     this.mesh.textureAlphaThreshold = alphaThreshold;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Refresh the elevation
    * @protected
@@ -328,6 +376,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     if (!this.mesh) return;
     this.mesh.elevation = this.document.elevation;
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Refresh the content and appearance of text.
@@ -341,6 +391,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     pixiText.alpha = textAlpha;
     pixiText.style = this._getTextStyle();
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Refresh the border frame that encloses the CardObject.
@@ -368,6 +420,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     border.lineStyle({width: thickness / 2, color: 0xFFFFFF, join: PIXI.LINE_JOIN.ROUND, alignment: 1})
       .drawShape(bounds);
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Adapted from `PrimarySpriteMesh#resize`, this helper method adjusts the contained SpriteMesh
@@ -413,13 +467,15 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     this.mesh._height = Math.abs(sy * textureHeight);
   }
 
-  /* -------------------------------------------- */
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   _onCreate(data, options, userId) {
     canvas.cards.objects.addChild(this);
     this.draw();
   }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   _onUpdate(changed, options, userId) {
@@ -465,6 +521,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     if (!this._propagateLeftClick(event)) event.stopPropagation();
   }
 
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   _canDragLeftStart(user, event) {
     if (game.paused && !game.user.isGM) {
@@ -478,6 +536,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     return true;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Card draw mode to use for this CardObject
    */
@@ -485,6 +545,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     if (this.document.flipped) return CONST.CARD_DRAW_MODES.LAST;
     return CONST.CARD_DRAW_MODES.FIRST;
   }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   _initializeDragLeft(event) {
@@ -523,6 +585,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     event.interactionData.clones = clones;
   }
 
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   _onDragLeftDrop(event) {
     // Ensure that we landed in bounds
@@ -534,6 +598,8 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     const updates = this._prepareDragLeftDropUpdates(event);
     if (updates) this.#commitDragLeftDropUpdates(updates);
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * @typedef DragUpdate
@@ -603,5 +669,4 @@ export default class CardObject extends foundry.canvas.placeables.PlaceableObjec
     }
     this.layer.clearPreviewContainer();
   }
-
 }

--- a/src/module/canvas/ControlsLayer.mjs
+++ b/src/module/canvas/ControlsLayer.mjs
@@ -1,0 +1,18 @@
+import CardLayer from "./CardLayer.mjs";
+
+/**
+ * A custom subclass of the controls layer that adds the ability to ping while on the cards layer.
+ */
+export default class CCMControlsLayer extends CONFIG.Canvas.layers.controls.layerClass {
+  /** @inheritdoc */
+  _onLongPress(event, origin) {
+    if (canvas.activeLayer instanceof CardLayer) {
+      const isCtrl = game.keyboard.isModifierActive("CONTROL");
+      if (!game.user.hasPermission("PING_CANVAS") || isCtrl) return;
+      event.interactionData.cancelled = true;
+      canvas.currentMouseManager.cancel(event); // Cancel drag workflow
+      return canvas.ping(origin);
+    }
+    else return super._onLongPress(event, origin);
+  }
+}

--- a/src/module/canvas/MoveCardBehavior.mjs
+++ b/src/module/canvas/MoveCardBehavior.mjs
@@ -3,15 +3,20 @@ import {MODULE_ID} from "../helpers.mjs";
 const fields = foundry.data.fields;
 
 export default class MoveCardBehavior extends foundry.data.regionBehaviors.RegionBehaviorType {
-
+  /** @inheritdoc */
   static LOCALIZATION_PREFIXES = ["CCM.MoveCardBehavior"];
 
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   static defineSchema() {
     return {
       targetStack: new fields.ForeignDocumentField(getDocumentClass("Cards")),
       keepCanvasCard: new fields.BooleanField()
     };
   }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static _createEventsField({events, initial} = {}) {
@@ -29,11 +34,15 @@ export default class MoveCardBehavior extends foundry.data.regionBehaviors.Regio
     }), setFieldOptions);
   }
 
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   static events = {
     [CCM_CONFIG.REGION_EVENTS.CARD_MOVE_IN]: this.#onCardMoveIn,
     [CCM_CONFIG.REGION_EVENTS.CARD_MOVE_OUT]: this.#onCardMoveOut
   };
+
+  /* -------------------------------------------------- */
 
   /**
    *
@@ -64,6 +73,8 @@ export default class MoveCardBehavior extends foundry.data.regionBehaviors.Regio
       card.pass(this.targetStack);
     }
   }
+
+  /* -------------------------------------------------- */
 
   /**
    *

--- a/src/module/canvas/_module.mjs
+++ b/src/module/canvas/_module.mjs
@@ -1,4 +1,5 @@
 export {default as CardLayer} from "./CardLayer.mjs";
 export {default as CardObject} from "./CardObject.mjs";
+export {default as CCMControlsLayer} from "./ControlsLayer.mjs";
 export {default as CanvasCard} from "./CanvasCard.mjs";
 export {default as MoveCardBehavior} from "./MoveCardBehavior.mjs";

--- a/src/module/helpers.mjs
+++ b/src/module/helpers.mjs
@@ -32,6 +32,8 @@ export function generateUpdates(valuePath, valueMod, {object, targetPath = "", i
   return updates;
 }
 
+/* -------------------------------------------------- */
+
 /**
  * Loops through an array of updates matching the ID of cards to an update array for their embedded collection
  * @param {Record<string, Array<{ _id: string } & Record<string, unknown>>>} processedUpdates
@@ -42,6 +44,8 @@ export async function processUpdates(processedUpdates) {
     else await game.cards.get(id).updateEmbeddedDocuments("Card", updates);
   }
 }
+
+/* -------------------------------------------------- */
 
 /**
  * Loop through player hands to see if the PlayerList needs to be re-rendered

--- a/src/module/hooks.mjs
+++ b/src/module/hooks.mjs
@@ -19,14 +19,19 @@ export function init() {
     group: "interface",
     layerClass: ccm_canvas.CardLayer
   };
-  CONFIG.Card.objectClass = ccm_canvas.CardObject;
-  CONFIG.Card.layerClass = ccm_canvas.CardLayer;
-  CONFIG.Card.hudClass = apps.CardHud;
+  CONFIG.Canvas.layers.controls.layerClass = ccm_canvas.CCMControlsLayer;
+  Object.assign(CONFIG.Card, {
+    objectClass: ccm_canvas.CardObject,
+    layerClass: ccm_canvas.CardLayer,
+    hudClass: apps.CardHud
+  });
   CONFIG.RegionBehavior.dataModels[MoveCardType] = ccm_canvas.MoveCardBehavior;
   CONFIG.RegionBehavior.typeIcons[MoveCardType] = "fa-solid fa-cards";
-  CONFIG.controlIcons.flip = "modules/complete-card-management/assets/icons/vertical-flip.svg";
-  CONFIG.controlIcons.rotate = "modules/complete-card-management/assets/icons/clockwise-rotation.svg";
-  CONFIG.controlIcons.shuffle = "modules/complete-card-management/assets/icons/shuffle.svg";
+  Object.assign(CONFIG.controlIcons, {
+    flip: "modules/complete-card-management/assets/icons/vertical-flip.svg",
+    rotate: "modules/complete-card-management/assets/icons/clockwise-rotation.svg",
+    shuffle: "modules/complete-card-management/assets/icons/shuffle.svg"
+  });
 
   ccm_canvas.CanvasCard.registerSettings();
 

--- a/src/module/patches.mjs
+++ b/src/module/patches.mjs
@@ -16,6 +16,8 @@ export function addCard(card) {
   return mesh;
 }
 
+/* -------------------------------------------------- */
+
 /**
  * Remove a CardObject from the layer
  *


### PR DESCRIPTION
1. Tons of code style adjustments, including adding `divs`
2. Subclassed ControlsLayer so that we can fire off pings while on the cards layer; Foundry hard checks for it being the TokenLayer and there's no other place to adjust.