### PR TITLE
[#170] Solution for ghost card bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2.1.2
+- Resolved ghost card issue from dropping a card on the canvas while it's set to function as a pile.
 - Fixed an issue where a canvas card could end up with a height and width of zero. The new minimums are CONST.GRID_SIZE, which is currently 20px.
 - Adjusted the z index of the Cards layer so it is below the layer created by the Sequencer module.
 - Fixed an issue with dragging and dropping to and from the Docked sheet.

--- a/src/module/api/singles.mjs
+++ b/src/module/api/singles.mjs
@@ -13,7 +13,7 @@ import {MODULE_ID} from "../helpers.mjs";
  * @param {number} [data.rotation] Rotation on the canvas (default: The card's rotation)
  * @param {number} [data.sort]     Sort value on the canvas (default: The card's sort)
  * @param {string} [data.sceneId]  ID of the scene to place (default: the current scene)
- * @returns {Card | Card}          The updated document
+ * @returns {Promise<Card | Card>}          The updated document
  */
 export async function placeCard(card, data = {}) {
   const scene = game.scenes.get(data.sceneId) ?? canvas.scene;

--- a/src/module/canvas/CanvasCard.mjs
+++ b/src/module/canvas/CanvasCard.mjs
@@ -416,6 +416,7 @@ export default class CanvasCard extends foundry.abstract.DataModel {
         ui.notifications.info(game.i18n.format("CCM.MoveCardBehavior.AddCard",
           {name: this.card.name, stack: d.name})
         );
+        this.delete();
         return this.card.pass(d);
       }
     }
@@ -425,6 +426,7 @@ export default class CanvasCard extends foundry.abstract.DataModel {
     const canvasPile = game.cards.get(canvasPileId);
     const parent = this.card.parent;
     if (!canvasPile || (parent === canvasPile)) return;
+    this.delete();
     return this.card.pass(canvasPile);
   }
 

--- a/src/module/hooks.mjs
+++ b/src/module/hooks.mjs
@@ -105,7 +105,7 @@ async function handleCardDrop(canvas, data) {
     return;
   }
 
-  api.placeCard(card, data);
+  await api.placeCard(card, data);
 }
 
 /* -------------------------------------------------- */
@@ -247,7 +247,7 @@ export async function updateCard(card, changed, options, userId) {
  */
 export async function deleteCard(card, options, userId) {
   if (card.canvasCard) {
-    card.canvasCard.object._onDelete(options, userId);
+    card.canvasCard.object?._onDelete(options, userId);
   }
 
   checkHandDisplayUpdate(card, "delete");


### PR DESCRIPTION
To nobody's surprise it was a race condition related to cards getting transferred while also not yet drawn. Fortunately prior work on a `delete` method that properly grabs and cleans up the mesh made it simpler.

Closes #170